### PR TITLE
Fix transfer size for non-FD frames and don't clear echo_id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,12 +77,33 @@ impl<'a, B: UsbBus, D: Device> GsCan<'a, B, D> {
         }
     }
 
+    /// Get the size of frame in USB packet transfer
+    ///
+    /// The size depends on whether the adapter is in FD or Normal mode, and also on whether
+    /// hardware timestamps are supported and enabled. Currently, hardware timestamps are NOT
+    /// supported, so these are the size of frames without timestamps.
+    fn frame_wire_len(frame: &host::Frame) -> usize {
+        if frame.flags.intersects(FrameFlag::FD) {
+            76
+        } else {
+            20
+        }
+    }
+
     fn enqueue_frame(&mut self, frame: host::Frame) {
+        let wire_len = Self::frame_wire_len(&frame);
+
         if self.out_frame.is_none() {
-            if self.write_endpoint.write(&frame.as_bytes()[..64]).is_ok() {
-                // first half write complete.
-                // defer second half of frame.
-                self.out_frame = Some(frame);
+            let first_chunk_len = wire_len.min(64);
+            if self
+                .write_endpoint
+                .write(&frame.as_bytes()[..first_chunk_len])
+                .is_ok()
+            {
+                // If needed, defer second half write.
+                if wire_len > 64 {
+                    self.out_frame = Some(frame);
+                }
             } else if self.out_queue.enqueue(frame).is_err() {
                 #[cfg(feature = "defmt-03")]
                 defmt::error!("Transmit queue full");
@@ -258,15 +279,27 @@ impl<B: UsbBus, D: Device> UsbClass<B> for GsCan<'_, B, D> {
         if self.out_frame.is_none() {
             // attempt sending new frame.
             if let Some(frame) = self.out_queue.peek() {
-                if self.write_endpoint.write(&frame.as_bytes()[..64]).is_ok() {
+                let wire_len = Self::frame_wire_len(frame);
+                let first_chunk_len = wire_len.min(64);
+                if self
+                    .write_endpoint
+                    .write(&frame.as_bytes()[..first_chunk_len])
+                    .is_ok()
+                {
                     let frame = self.out_queue.dequeue().unwrap(); // remove from queue
-                    self.out_frame = Some(frame);
+                    if wire_len > 64 {
+                        self.out_frame = Some(frame);
+                    }
                 }
             }
         } else {
             // attempt sending second frame half.
-            self.out_frame
-                .take_if(|frame| self.write_endpoint.write(&frame.as_bytes()[64..76]).is_ok());
+            self.out_frame.take_if(|frame| {
+                let wire_len = Self::frame_wire_len(frame);
+                self.write_endpoint
+                    .write(&frame.as_bytes()[64..wire_len])
+                    .is_ok()
+            });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl<B: UsbBus, D: Device> UsbClass<B> for GsCan<'_, B, D> {
             return;
         }
 
-        let mut frame = match self.in_frame {
+        let frame = match self.in_frame {
             None => {
                 let mut frame = host::Frame::new_zeroed();
                 self.read_endpoint
@@ -303,8 +303,6 @@ impl<B: UsbBus, D: Device> UsbClass<B> for GsCan<'_, B, D> {
                 frame
             }
         };
-
-        frame.echo_id = 0; // tx complete
 
         self.device.receive(frame.interface, &frame);
 


### PR DESCRIPTION
Thanks for sharing this! It really helped me get going fast. However, I hit some issues using this with linux socketcan and non-FD CAN frames. These changes seem to fix a couple issues which were causing the problems: 

## Transfer size

The linux gs_usb driver does not work unless the read transfer size size is the expected length. For non-timestamped normal CAN packets, that's 20 bytes. Currently, things will break if the `Feature::HW_TIMESTAMP` flag is set, because then the gs_usb driver will enable HW timestamping and expect 24 bytes. I'd like to also extend this to support HW timestamping, but will save that for another day. 

## Echo ID

I'm not sure why, but echo_id was being always set to 0. My understanding is that this flag should be returned to the host as-is. This works most of the time, when only one TX packet is sent at a time, but if you send packets quickly (at least using the linux gs_usb driver) then echo_id will not always be 0 and acknowledgements don't happen correctly.

I'm marking this as a draft for now and submitting in case you have any input, because I realized I need to do some more testing. It seems like the linux driver assumes there will always be only one CAN frame per URB. However, with 20 byte endpoint writes, I'm not sure that anything is ensuring this. I think the endpoint will queue up to 64 bytes -- so if 3 packets get written to the endpoint, and then the transfer occurs, 2 packets will get dropped. I need to test this and figure out what to do about it if  true.